### PR TITLE
Add support for shifting the image

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ Output width in pixel.
 __*`height`*__  
 Output height in pixel.
 
+__*`src_left`*__  
+Left shift in pixel.
+
+__*`src_top`*__  
+Top shift in pixel.
+
 __*`device`*__  
 Possible values are "cuda" to use with an Nvidia GPU, or "cpu". This will be extremely slow on CPU.
 

--- a/vs_liif/__init__.py
+++ b/vs_liif/__init__.py
@@ -7,6 +7,8 @@ def resize(
     clip: vs.VideoNode,
     width: int = 256,
     height: int = 256,
+    src_left: float = 0.0,
+    src_top: float = 0.0,
     device: str = 'cuda',
 ) -> vs.VideoNode:
 
@@ -26,7 +28,7 @@ def resize(
         img = torch.from_numpy(img[0]).to(device)
 
         with torch.no_grad():
-            output = process_image.process_frame(model, img, (height, width), device=device)
+            output = process_image.process_frame(model, img, (height, width), src_left=src_left, src_top=src_top, device=device)
 
         output = torch.unsqueeze(output, 0)
         output = output.cpu().detach().numpy()

--- a/vs_liif/process_image.py
+++ b/vs_liif/process_image.py
@@ -13,13 +13,13 @@ def get_model(device='cpu'):
     model = models.make(model, load_sd=True).to(device)
     return model
 
-def process_frame(model, img, resolution, device='cpu'):
+def process_frame(model, img, resolution, src_left=0.0, src_top=0.0, device='cpu'):
     img = img.to(device)
     if isinstance(resolution, str):
         h, w = map(int, resolution.split(','))
     else:
         h, w = resolution
-    coord = utils.make_coord((h, w)).to(device)
+    coord = utils.make_coord((h, w), src_left=src_left, src_top=src_top).to(device)
     cell = torch.ones_like(coord).to(device)
     cell[:, 0] *= 2 / h
     cell[:, 1] *= 2 / w

--- a/vs_liif/utils.py
+++ b/vs_liif/utils.py
@@ -1,7 +1,7 @@
 import torch
 
-def make_coord(shape, ranges=None, flatten=True):
-    """ Make coordinates at grid centers.
+def make_coord(shape, ranges=None, flatten=True, src_left=0.0, src_top=0.0):
+    """ Make coordinates at grid centers with optional subpixel shifts.
     """
     coord_seqs = []
     for i, n in enumerate(shape):
@@ -10,7 +10,11 @@ def make_coord(shape, ranges=None, flatten=True):
         else:
             v0, v1 = ranges[i]
         r = (v1 - v0) / (2 * n)
-        seq = v0 + r + (2 * r) * torch.arange(n).float()
+        if i == 0:
+            shift = src_top * (v1 - v0) / n
+        else:
+            shift = src_left * (v1 - v0) / n
+        seq = v0 + r + shift + (2 * r) * torch.arange(n).float()
         coord_seqs.append(seq)
     ret = torch.stack(torch.meshgrid(*coord_seqs, indexing='ij'), dim=-1)
     if flatten:


### PR DESCRIPTION
The new `src_left` and `src_top` arguments allow for subpixel shifts, in the same way as VapourSynth's built-in scalers.

I'd also be interested in having `src_width` and `src_height`, but shifting fulfills my immediate needs.  
Let me know if you want to implement them.